### PR TITLE
Fix log typo in delete expired messages job

### DIFF
--- a/server/plugins/delete.expired.messages.job.ts
+++ b/server/plugins/delete.expired.messages.job.ts
@@ -26,6 +26,6 @@ async function deleteExpiredMessages () {
 
     console.info(`${JOB_NAME} completed successfully.`);
   } catch (err) {
-    console.error(`Error occured on ${JOB_NAME}.`, err);
+    console.error(`Error occurred on ${JOB_NAME}.`, err);
   }
 }


### PR DESCRIPTION
## Summary
- fix a typo in `delete.expired.messages.job.ts`

## Testing
- `npm run lint` *(fails: couldn't find ESLint configuration)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc1c4eb248321ae628b9043f923b4