### PR TITLE
Update sanitizeUrl test descriptions

### DIFF
--- a/tests/utils/sanitize.url.spec.ts
+++ b/tests/utils/sanitize.url.spec.ts
@@ -4,13 +4,13 @@ import { describe, it, expect } from "vitest";
 import sanitizeUrl from "~/utils/sanitize.url";
 
 describe("sanitizeUrl", () => {
-  it("should return the same URL and false if the path does not exist in the URL", () => {
+  it("should return the same URL if the path does not exist in the URL", () => {
     const url = "https://example.com/abc";
     const sanitizedUrl = sanitizeUrl(url);
     expect(sanitizedUrl).toBe(url);
   });
 
-  it("should return the URL with the path and true if the path exists in the URL", () => {
+  it("should return the URL with the path if the path exists in the URL", () => {
     const url = "https://example.com/m/123abc";
     const sanitizedUrl = sanitizeUrl(url);
     expect(sanitizedUrl).toBe("https://example.com/m/");


### PR DESCRIPTION
## Summary
- adjust sanitizeUrl test titles to remove boolean references

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683fc461b00083219e5b1ca20d2f56a4