### PR TITLE
Ensure fresh wrapper for each NewMessage test

### DIFF
--- a/tests/pages/m/new.spec.ts
+++ b/tests/pages/m/new.spec.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 // @vitest-environment happy-dom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import NewMessage from "@/pages/m/new.vue";
 
 describe("Creating NewMessage", () => {
-  const wrapper = mount(NewMessage);
+  let wrapper: ReturnType<typeof mount>;
+
+  beforeEach(() => {
+    wrapper = mount(NewMessage);
+  });
 
   it("renders without crashing", () => {
     expect(wrapper.exists()).toBe(true);


### PR DESCRIPTION
## Summary
- update `tests/pages/m/new.spec.ts` to re-mount `NewMessage` in `beforeEach`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683fc68883188321bf78eb62609a27b5